### PR TITLE
added support for vagrant-librarian-chef plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vagrant
 Berksfile.lock
+Cheffile.lock
+/tmp
 /cookbooks

--- a/Cheffile
+++ b/Cheffile
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+#^syntax detection
+site 'http://community.opscode.com/api/v1'
+
+cookbook 'apache2'
+cookbook 'apt'
+cookbook 'build-essential'
+cookbook 'dotdeb', :git => 'git://github.com/homemade/chef-dotdeb.git'
+cookbook 'memcached'
+cookbook 'mysql'
+cookbook 'openssl'
+cookbook 'php'
+cookbook 'postfix'
+cookbook 'app', :path => './site-cookbooks/app'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,8 @@
 
 Vagrant.configure("2") do |config|
   # Enable Berkshelf support
-  config.berkshelf.enabled = true
+  # config.berkshelf.enabled = true
+
 
   # Define VM box to use
   config.vm.box = "precise32"
@@ -25,6 +26,10 @@ Vagrant.configure("2") do |config|
 
   # Enable and configure chef solo
   config.vm.provision :chef_solo do |chef|
+
+  # Set cookbooks_path if using Librarian-Chef (https://github.com/applicationsonline/librarian-chef)
+  chef.cookbooks_path = "cookbooks"
+
     chef.add_recipe "app::packages"
     chef.add_recipe "app::web_server"
     chef.add_recipe "app::vhost"


### PR DESCRIPTION
I tend to use Librarian-Chef over Berkshelf, so I added support for it. This works when I comment out the postfix cookbook in both the Vagrantfile and Cheffile, per issue #11.
