### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The idea is for developers to fork this and add additional software and configur
 * [Berkshelf](http://berkshelf.com)
 	* `gem install berkshelf`
 * [vagrant-berkshelf](https://github.com/riotgames/vagrant-berkshelf)
-	* `vagrant plugin install vagrant-berkshelf`
+	* `vagrant plugin install vagrant-berkshelf --plugin-version '>= 2.0.1'`
 * [vagrant-hostmanager](https://github.com/smdahlen/vagrant-hostmanager)
 	* `vagrant plugin install vagrant-hostmanager`
 * [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus)


### PR DESCRIPTION
install >= 2.0.1 version of vagrant-berkshelf, otherwise, it will report error as following:

cannot load such file -- hashie/hash_extensions
